### PR TITLE
Bump zookeeper from 3.4.6 to 3.4.14 in /10 Zookeeper

### DIFF
--- a/10 Zookeeper/pom.xml
+++ b/10 Zookeeper/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.6</version>
+            <version>3.4.14</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Bumps zookeeper from 3.4.6 to 3.4.14.

Signed-off-by: dependabot[bot] <support@github.com>